### PR TITLE
feat: Add solar storm alert and QRZ logbook

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -171,6 +171,48 @@ footer {
     height: 24px;
 }
 
+.solar-storm-alert {
+    background-color: #cc0000;
+    color: white;
+    text-align: center;
+    padding: 10px;
+    font-size: 1.1em;
+    font-weight: bold;
+}
+
+/* Logbook Section */
+.logbook {
+    margin-top: 2rem;
+    padding: 2rem 1rem;
+    background-color: #1f1f1f;
+    border-radius: 8px;
+    text-align: center;
+}
+
+.logbook h2 {
+    font-size: 1.8rem;
+    color: #e0e0e0;
+    margin-bottom: 1.5rem;
+}
+
+.iframe-container {
+    position: relative;
+    width: 100%;
+    max-width: 640px;
+    margin: 0 auto;
+    overflow: hidden;
+    padding-top: 78.125%; /* Aspect Ratio 500/640 */
+}
+
+.iframe-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     .nav-links {

--- a/index.html
+++ b/index.html
@@ -19,6 +19,10 @@
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 
+    <div id="solar-storm-alert" class="solar-storm-alert" style="display: none;">
+        <p data-lang="solarStorm.alert"><strong>ALERT:</strong> Geomagnetic Storm in Progress!</p>
+    </div>
+
     <header>
         <nav>
             <div class="logo">
@@ -45,17 +49,24 @@
             <h2 data-lang="solar_data_title">Live Solar Data</h2>
             <div class="data-grid">
                 <div class="data-item">
-                    <span class="label">SFI:</span>
+                    <span class="label" data-lang="sfi_label">SFI:</span>
                     <span id="sfi-value">--</span>
                 </div>
                 <div class="data-item">
-                    <span class="label">K-Index:</span>
+                    <span class="label" data-lang="k_index_label">K-Index:</span>
                     <span id="k-index-value">--</span>
                 </div>
                 <div class="data-item">
-                    <span class="label">A-Index:</span>
+                    <span class="label" data-lang="a_index_label">A-Index:</span>
                     <span id="a-index-value">--</span>
                 </div>
+            </div>
+        </section>
+
+        <section class="logbook">
+            <h2 data-lang="latest_qsos_title">Latest QSOs</h2>
+            <div class="iframe-container">
+                <iframe align="top" frameborder="0" height="500" scrolling="yes" src="https://logbook.qrz.com/lbstat/OH3CYT/" width="640"></iframe>
             </div>
         </section>
     </main>
@@ -67,10 +78,10 @@
                 <span data-lang="github">Github</span>
             </a>
             <a href="https://www.qrz.com/db/OH3CYT" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><text x="4" y="18" font-size="12" fill="currentColor">QRZ</text></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 50 24" fill="currentColor"><style>.qrz-text { font: bold 20px sans-serif; }</style><text x="0" y="18" class="qrz-text">QRZ</text></svg>
                 <span data-lang="qrz">QRZ</span>
             </a>
-            <a href="http://websdr.some-websdr.com" target="_blank">
+            <a href="https://oh3ac.oh3cyt.com" target="_blank">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12 L12 22 M8 22 L16 22 M12 12 L20 4 M12 12 L4 4 M8 12 L16 12"/></svg>
                 <span data-lang="websdr">WebSDR</span>
             </a>

--- a/js/en.json
+++ b/js/en.json
@@ -26,10 +26,17 @@
     "other_1": "RTL-SDR v3",
     "other_2": "RTL-SDR v4",
     "solar_data_title": "Live Solar Data",
+    "sfi_label": "SFI:",
+    "k_index_label": "K-Index:",
+    "a_index_label": "A-Index:",
     "maintenance_title": "Under Maintenance",
     "maintenance_text": "This website is currently undergoing scheduled maintenance. Please check back later.",
     "not_found_title": "404 - Page Not Found",
     "not_found_text": "The page you are looking for does not exist. Go back to the homepage.",
     "short_maintenance_title": "Short Maintenance",
-    "short_maintenance_text": "We are currently performing a short maintenance. We will be back shortly."
+    "short_maintenance_text": "We are currently performing a short maintenance. We will be back shortly.",
+    "solarStorm": {
+        "alert": "<strong>ALERT:</strong> Geomagnetic Storm in Progress!"
+    },
+    "latest_qsos_title": "Latest QSOs"
 }

--- a/js/fi.json
+++ b/js/fi.json
@@ -26,10 +26,17 @@
     "other_1": "RTL-SDR v3",
     "other_2": "RTL-SDR v4",
     "solar_data_title": "Live Aurinkodata",
+    "sfi_label": "SFI:",
+    "k_index_label": "K-indeksi:",
+    "a_index_label": "A-indeksi:",
     "maintenance_title": "Huollossa",
     "maintenance_text": "Verkkosivusto on tällä hetkellä suunnitellussa huollossa. Yritä myöhemmin uudelleen.",
     "not_found_title": "404 - Sivua ei löytynyt",
     "not_found_text": "Etsimääsi sivua ei ole olemassa. Palaa etusivulle.",
     "short_maintenance_title": "Lyhyt huoltokatko",
-    "short_maintenance_text": "Teemme parhaillaan lyhyttä huoltokatkoa. Palaamme pian."
+    "short_maintenance_text": "Teemme parhaillaan lyhyttä huoltokatkoa. Palaamme pian.",
+    "solarStorm": {
+        "alert": "<strong>HÄLYTYS:</strong> Geomagneettinen myrsky käynnissä!"
+    },
+    "latest_qsos_title": "Viimeisimmät QSO:t"
 }

--- a/pages/404.html
+++ b/pages/404.html
@@ -37,10 +37,10 @@
                 <span data-lang="github">Github</span>
             </a>
             <a href="https://www.qrz.com/db/OH3CYT" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><text x="4" y="18" font-size="12" fill="currentColor">QRZ</text></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 50 24" fill="currentColor"><style>.qrz-text { font: bold 20px sans-serif; }</style><text x="0" y="18" class="qrz-text">QRZ</text></svg>
                 <span data-lang="qrz">QRZ</span>
             </a>
-            <a href="http://websdr.some-websdr.com" target="_blank">
+            <a href="https://oh3ac.oh3cyt.com" target="_blank">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12 L12 22 M8 22 L16 22 M12 12 L20 4 M12 12 L4 4 M8 12 L16 12"/></svg>
                 <span data-lang="websdr">WebSDR</span>
             </a>

--- a/pages/equipment.html
+++ b/pages/equipment.html
@@ -67,10 +67,10 @@
                 <span data-lang="github">Github</span>
             </a>
             <a href="https://www.qrz.com/db/OH3CYT" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><text x="4" y="18" font-size="12" fill="currentColor">QRZ</text></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 50 24" fill="currentColor"><style>.qrz-text { font: bold 20px sans-serif; }</style><text x="0" y="18" class="qrz-text">QRZ</text></svg>
                 <span data-lang="qrz">QRZ</span>
             </a>
-            <a href="http://websdr.some-websdr.com" target="_blank">
+            <a href="https://oh3ac.oh3cyt.com" target="_blank">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12 L12 22 M8 22 L16 22 M12 12 L20 4 M12 12 L4 4 M8 12 L16 12"/></svg>
                 <span data-lang="websdr">WebSDR</span>
             </a>

--- a/pages/shortmaintenance.html
+++ b/pages/shortmaintenance.html
@@ -37,10 +37,10 @@
                 <span data-lang="github">Github</span>
             </a>
             <a href="https://www.qrz.com/db/OH3CYT" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><text x="4" y="18" font-size="12" fill="currentColor">QRZ</text></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 50 24" fill="currentColor"><style>.qrz-text { font: bold 20px sans-serif; }</style><text x="0" y="18" class="qrz-text">QRZ</text></svg>
                 <span data-lang="qrz">QRZ</span>
             </a>
-            <a href="http://websdr.some-websdr.com" target="_blank">
+            <a href="https://oh3ac.oh3cyt.com" target="_blank">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12 L12 22 M8 22 L16 22 M12 12 L20 4 M12 12 L4 4 M8 12 L16 12"/></svg>
                 <span data-lang="websdr">WebSDR</span>
             </a>

--- a/pages/undermaintenance.html
+++ b/pages/undermaintenance.html
@@ -37,10 +37,10 @@
                 <span data-lang="github">Github</span>
             </a>
             <a href="https://www.qrz.com/db/OH3CYT" target="_blank">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><text x="4" y="18" font-size="12" fill="currentColor">QRZ</text></svg>
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 50 24" fill="currentColor"><style>.qrz-text { font: bold 20px sans-serif; }</style><text x="0" y="18" class="qrz-text">QRZ</text></svg>
                 <span data-lang="qrz">QRZ</span>
             </a>
-            <a href="http://websdr.some-websdr.com" target="_blank">
+            <a href="https://oh3ac.oh3cyt.com" target="_blank">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 12 L12 22 M8 22 L16 22 M12 12 L20 4 M12 12 L4 4 M8 12 L16 12"/></svg>
                 <span data-lang="websdr">WebSDR</span>
             </a>


### PR DESCRIPTION
This commit introduces several new features and enhancements to the website:

- Implements a "Solar Storm Alert" banner that appears at the top of the page when a geomagnetic storm warning (K-index >= 5) is issued by NOAA SWPC. The feature fetches data from the `alerts.json` endpoint.
- Adds a new "Latest QSOs" section to the homepage, embedding your QRZ.com logbook via an iframe.
- Makes the embedded logbook responsive to fit different screen sizes.
- Enhances the translation script to handle nested JSON keys and render HTML content within translations.
- Adds Finnish translations for the new UI elements.