### PR TITLE
This change centralizes the Google Analytics tracking code into a sin…

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,19 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OH3CYT - Ham Radio</title>
     <link rel="stylesheet" href="css/style.css">
-    <!-- Google Tag Manager -->
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-XXXXXXX');</script>
-    <!-- End Google Tag Manager -->
+    <script src="js/gtag.js"></script>
 </head>
 <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-XXXXXXX"
-    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <!-- End Google Tag Manager (noscript) -->
 
     <div id="solar-storm-alert" class="solar-storm-alert" style="display: none;">
         <p data-lang="solarStorm.alert"><strong>ALERT:</strong> Geomagnetic Storm in Progress!</p>

--- a/js/gtag.js
+++ b/js/gtag.js
@@ -1,0 +1,5 @@
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+
+gtag('config', 'G-B2GD7H6D8B');

--- a/pages/404.html
+++ b/pages/404.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>404 Not Found - OH3CYT</title>
     <link rel="stylesheet" href="../css/style.css">
+    <script src="../js/gtag.js"></script>
 </head>
 <body>
     <header>

--- a/pages/equipment.html
+++ b/pages/equipment.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Equipment - OH3CYT</title>
     <link rel="stylesheet" href="../css/style.css">
+    <script src="../js/gtag.js"></script>
 </head>
 <body>
     <header>

--- a/pages/logbook.html
+++ b/pages/logbook.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OH3CYT - Contest Logbook</title>
     <link rel="stylesheet" href="../css/style.css">
+    <script src="../js/gtag.js"></script>
     <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css" />
     <script src="https://unpkg.com/leaflet"></script>
     <script src="https://unpkg.com/@joergdietrich/leaflet.terminator"></script>

--- a/pages/maintenance.html
+++ b/pages/maintenance.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Maintenance - OH3CYT</title>
     <link rel="stylesheet" href="../css/style.css">
+    <script src="../js/gtag.js"></script>
 </head>
 <body>
     <header>

--- a/pages/shortmaintenance.html
+++ b/pages/shortmaintenance.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Short Maintenance - OH3CYT</title>
     <link rel="stylesheet" href="../css/style.css">
+    <script src="../js/gtag.js"></script>
 </head>
 <body>
     <header>

--- a/pages/undermaintenance.html
+++ b/pages/undermaintenance.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Under Maintenance - OH3CYT</title>
     <link rel="stylesheet" href="../css/style.css">
+    <script src="../js/gtag.js"></script>
 </head>
 <body>
     <header>


### PR DESCRIPTION
…gle `js/gtag.js` file.

Previously, the Google Tag Manager script was included directly in `index.html`. This change removes the inline script and replaces it with a reference to the new `js/gtag.js` file.

The `js/gtag.js` file contains the Google Analytics tracking code with the ID `G-B2GD7H6D8B`.

The following files were modified to include the new `js/gtag.js` script:
*   `index.html`
*   `pages/404.html`
*   `pages/equipment.html`
*   `pages/logbook.html`
*   `pages/maintenance.html`
*   `pages/shortmaintenance.html`
*   `pages/undermaintenance.html`

This change addresses the user's request to have a single, centralized gtag file for all pages. An initial error where the `.js` file contained HTML tags was also corrected.