### PR TITLE
Fix Google Analytics implementation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OH3CYT - Ham Radio</title>
     <link rel="stylesheet" href="css/style.css">
-    <script src="js/gtag.js"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B2GD7H6D8B"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-B2GD7H6D8B');
+    </script>
 </head>
 <body>
 

--- a/js/gtag.js
+++ b/js/gtag.js
@@ -1,5 +1,0 @@
-window.dataLayer = window.dataLayer || [];
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-
-gtag('config', 'G-B2GD7H6D8B');


### PR DESCRIPTION
Replaces the broken and incomplete Google Analytics setup with the standard, recommended snippet from Google.

The previous implementation had the gtag configuration in a local `js/gtag.js` file but was missing the necessary script to load the analytics library from Google's servers.

This change moves the entire Google Analytics snippet into `index.html` and removes the now-redundant `js/gtag.js` file. This ensures that analytics tracking will work correctly.